### PR TITLE
Fix compilation issue on `CALayer` due to wrong import

### DIFF
--- a/SwiftMessages/CALayer+Utils.swift
+++ b/SwiftMessages/CALayer+Utils.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2018 SwiftKick Mobile. All rights reserved.
 //
 
-import CoreGraphics
+import QuartzCore
 
 extension CALayer {
     func findAnimation(forKeyPath keyPath: String) -> CABasicAnimation? {


### PR DESCRIPTION
Hi,

Due to no support of resource bundle in SwiftPM your [PR](https://github.com/SwiftKickMobile/SwiftMessages/pull/297) is blocked 

Today I use your fork in my Continuous Integration system just to test compilation, not to deploy.

But there is some compilation issues because of bad import (Xcode is nicer, it allow to forgot import of UIKit)
```c
.../SwiftMessages/CALayer+Utils.swift:11:11: error: use of undeclared type 'CALayer'
.../SwiftMessages/CALayer+Utils.swift:12:55: error: use of undeclared type 'CABasicAnimation'
```

I do the compilation with this:
```sh
sdk=`xcrun -sdk iphonesimulator -show-sdk-path`
sdkVersion=`echo $sdk | sed -E 's/.*iPhoneSimulator(.*)\.sdk/\1/'`
swift build  -Xswiftc "-sdk" -Xswiftc "$sdk" -Xswiftc "-target" -Xswiftc "x86_64-apple-ios$sdkVersion-simulator"
```

So If your PR is merged one day, it would be good if the framework compile.
An alternative is to import UIKit instead